### PR TITLE
Avro consumer support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   redpanda-0:
     command:
@@ -46,8 +44,8 @@ services:
       POSTGRES_PASSWORD: "change_me"
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
 
-  conduktor-platform:
-    image: conduktor/conduktor-platform:1.24.1
+  conduktor-console:
+    image: conduktor/conduktor-console:1.26.0
     depends_on:
       - postgresql
       - redpanda-0
@@ -94,7 +92,7 @@ services:
 
   # Kafka proxy from Conduktor
   # conduktor-gateway:
-  #   image: conduktor/conduktor-gateway:3.1.1
+  #   image: conduktor/conduktor-gateway:3.2.0
   #   hostname: conduktor-gateway
   #   container_name: conduktor-gateway
   #   environment:


### PR DESCRIPTION
1. Add support for consuming avro message. Choose in config json or avro
2. Moved from experimental consumer class to the supported class
3. Decode key. Wasn't properly decoding the key hence printing out `b'<key>'` rather than `<key>`
4. Also bumped Conduktor versions